### PR TITLE
Use old isNaN

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = prettierBytes
 
 function prettierBytes (num) {
-  if (typeof num !== 'number' || Number.isNaN(num)) {
+  if (typeof num !== 'number' || isNaN(num)) {
     throw new TypeError('Expected a number, got ' + typeof num)
   }
 


### PR DESCRIPTION
Use `isNaN()` instead of `Number.isNaN()`. Resolves #3.